### PR TITLE
[URS-545] Add hash_id UpdateRequestProcessorChain to solrconfig

### DIFF
--- a/templates/hyrax_solrconfig/solrconfig_xml.j2
+++ b/templates/hyrax_solrconfig/solrconfig_xml.j2
@@ -52,6 +52,12 @@
 
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
 
+  <requestHandler name="/update" class="solr.UpdateRequestHandler" >
+    <lst name="defaults">
+      <str name="update.chain">add_hash_id</str>
+    </lst>
+  </requestHandler>
+
   <!-- config for the admin interface -->
   <admin>
     <defaultQuery>*:*</defaultQuery>
@@ -200,6 +206,20 @@
       <str>termsComponent</str>
     </arr>
   </requestHandler>
+
+  <updateRequestProcessorChain name="add_hash_id">
+    <processor class="solr.processor.SignatureUpdateProcessorFactory">
+      <bool name="enabled">true</bool>
+      <str name="signatureField">hashed_id_ssi</str>
+      <bool name="overwriteDupes">false</bool>
+      <str name="fields">id</str>
+      <str name="signatureClass">solr.processor.Lookup3Signature</str>
+      <str name="defType">lucene</str>
+    </processor>
+    <processor class="solr.LogUpdateProcessorFactory" />
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+
 
 <!-- Spell Check
 


### PR DESCRIPTION
* Add the required hash_id field to the solrconfig template, to
facilitate the creation of sitemaps via the SUL sitemape gem.