### PR TITLE
Revert "Merge pull request #17 from UCLALibrary/APPS-480/ursus-solr-c…

### DIFF
--- a/files/hyrax_solr-conf/update-script.js
+++ b/files/hyrax_solr-conf/update-script.js
@@ -53,7 +53,7 @@ function processAdd(cmd) {
     var XMLResponseParser = Java.type(
       'org.apache.solr.client.solrj.impl.XMLResponseParser'
     );
-    urlString = '{{ solr_ursus_url }}';
+    urlString = 'http://localhost:8983/solr/ursus';
     logger.info('update-script#processAdd: SOLR_URSUS_URL=' + urlString);
     logger.info('update-script#processAdd: SolrClient=' + SolrClient);
     solrclient = new HttpSolrClient.Builder(urlString).build();

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -22,15 +22,6 @@
   with_items: "{{ solr_cores }}"
   when: item.type != "default"
 
-- name: Put in place application-specific update-script.js files
-  template:
-    src: "{{ item.type }}_solrconfig/update-script.js.j2"
-    dest: "{{ solr_data_dir }}/data/{{ item.ident }}/conf/update-script.js"
-  with_items: "{{ solr_cores }}"
-  when:
-    - item.type != "default"
-    - solr_ursus_url is defined
-
 - name: Set correct ownership of the Solr core directories
   file:
     path: "{{ solr_data_dir }}/data/{{ item.ident }}/conf"


### PR DESCRIPTION
…ore"

This reverts commit ba6ec132c8496991db0e2b27d925938690e0c193, reversing
changes made to 37bb9830e9adc370ac8d164724508571926ae9e0.

Reverts support for solr_ursus_url

The problem was ursus core was using calursus(hyrax) configs, causing an
infinite loop.