### PR TITLE
Remove update processor for Hash ID field

### DIFF
--- a/templates/ursus_solrconfig/solrconfig_xml.j2
+++ b/templates/ursus_solrconfig/solrconfig_xml.j2
@@ -233,15 +233,6 @@
       </arr>
     </processor>
 
-    <processor class="solr.processor.SignatureUpdateProcessorFactory">
-      <bool name="enabled">true</bool>
-      <str name="signatureField">hashed_id_ssi</str>
-      <bool name="overwriteDupes">false</bool>
-      <str name="fields">id</str>
-      <str name="signatureClass">solr.processor.Lookup3Signature</str>
-      <str name="defType">lucene</str>
-    </processor>
-
     <processor class="solr.LogUpdateProcessorFactory" />
     <processor class="solr.RunUpdateProcessorFactory" />
   </updateRequestProcessorChain>


### PR DESCRIPTION
This PR will fix following error

org.apache.solr.client.solrj.impl.HttpSolrClient$RemoteSolrException: Error from server at http://localhost:8983/solr/ursus: ERROR: [doc=ark:/21198/zz002c9dbn] multiple values encountered for non multiValued field hashed_id_ssi: [6bd4d3740ef94b3d, c34d69620bb6f5c4]
	