### PR TITLE
Add /replication to the master url

### DIFF
--- a/templates/avalon_solrconfig/solrconfig_xml.j2
+++ b/templates/avalon_solrconfig/solrconfig_xml.j2
@@ -35,8 +35,7 @@
   <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />
 
-  <directoryFactory name="DirectoryFactory"
-                    class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}">
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}">
   </directoryFactory>
 
   <codecFactory class="solr.SchemaCodecFactory"/>
@@ -46,7 +45,7 @@
 
   <dataDir>${solr.blacklight-core.data.dir:}</dataDir>
 
-  <requestDispatcher handleSelect="true" >
+  <requestDispatcher handleSelect="true">
     <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="2048000" />
   </requestDispatcher>
 
@@ -85,23 +84,23 @@
     <!-- default values for query parameters can be specified, these
          will be overridden by parameters in the request
       -->
-     <lst name="defaults">
-       <str name="defType">edismax</str>
-       <str name="echoParams">explicit</str>
-       <str name="q.alt">*:*</str>
-       <str name="q.op">OR</str>
-       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
-       <int name="qs">1</int>
-       <int name="ps">2</int>
-       <float name="tie">0.01</float>
-       <!-- this qf and pf are used by default, if not otherwise specified by
+    <lst name="defaults">
+      <str name="defType">edismax</str>
+      <str name="echoParams">explicit</str>
+      <str name="q.alt">*:*</str>
+      <str name="q.op">OR</str>
+      <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+      <int name="qs">1</int>
+      <int name="ps">2</int>
+      <float name="tie">0.01</float>
+      <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the
             "keywords" search. See the author_qf/author_pf, title_qf, etc
             below, which the default blacklight_config will specify for
             those searches. You may also be interested in:
             http://wiki.apache.org/solr/LocalParams
        -->
-        <str name="qf">
+      <str name="qf">
           id
           title_tesi^10.0
           section_label_tesim^5.0
@@ -110,58 +109,58 @@
           all_text_timv^1.0
           active_fedora_model_ssi
           object_type_si
-        </str>
-        <str name="pf">
+      </str>
+      <str name="pf">
           title_tesi^10.0
           section_label_tesim^5.0
           creator_ssim^3.0
           date_sim^3.0
           all_text_timv^1.0
-        </str>
+      </str>
 
-       <str name="author_qf">
+      <str name="author_qf">
           author_tesim
-       </str>
-       <str name="author_pf">
-       </str>
-       <str name="title_qf">
+      </str>
+      <str name="author_pf">
+      </str>
+      <str name="title_qf">
           title_tesim
-       </str>
-       <str name="title_pf">
-       </str>
-       <str name="subject_qf">
+      </str>
+      <str name="title_pf">
+      </str>
+      <str name="subject_qf">
           subject_tesim
-       </str>
-       <str name="subject_pf">
-       </str>
+      </str>
+      <str name="subject_pf">
+      </str>
 
-       <str name="fl">
+      <str name="fl">
          *,
          score
-       </str>
+      </str>
 
-       <str name="facet">true</str>
-       <str name="facet.mincount">1</str>
+      <str name="facet">true</str>
+      <str name="facet.mincount">1</str>
 
-       <str name="spellcheck">true</str>
-       <str name="spellcheck.dictionary">default</str>
-       <str name="spellcheck.onlyMorePopular">true</str>
-       <str name="spellcheck.extendedResults">true</str>
-       <str name="spellcheck.collate">false</str>
-       <str name="spellcheck.count">5</str>
+      <str name="spellcheck">true</str>
+      <str name="spellcheck.dictionary">default</str>
+      <str name="spellcheck.onlyMorePopular">true</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.collate">false</str>
+      <str name="spellcheck.count">5</str>
 
-     </lst>
+    </lst>
     <arr name="last-components">
       <str>spellcheck</str>
     </arr>
   </requestHandler>
 
-  <requestHandler name="permissions" class="solr.SearchHandler" >
+  <requestHandler name="permissions" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="facet">off</str>
       <str name="echoParams">all</str>
       <str name="rows">1</str>
-      <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
+      <str name="q">{!raw f=id v=$id}</str>      <!-- use id=666 instead of q=id:666 -->
       <str name="fl">
         id,
         access_ssim,
@@ -180,23 +179,23 @@
   </requestHandler>
 
   <requestHandler name="standard" class="solr.SearchHandler">
-     <lst name="defaults">
-       <str name="echoParams">explicit</str>
-       <str name="defType">lucene</str>
-     </lst>
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="defType">lucene</str>
+    </lst>
   </requestHandler>
 
   <!-- for requests to get a single document; use id=666 instead of q=id:666 -->
-  <requestHandler name="document" class="solr.SearchHandler" >
+  <requestHandler name="document" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="echoParams">all</str>
       <str name="fl">*</str>
       <str name="rows">1</str>
-      <str name="q">{!term f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
+      <str name="q">{!term f=id v=$id}</str>      <!-- use id=666 instead of q=id:666 -->
     </lst>
   </requestHandler>
 
-<!-- Spell Check
+  <!-- Spell Check
 
         The spell check component can return a list of alternative spelling
         suggestions.
@@ -334,7 +333,7 @@
   8 {% if solr_replication_node == "slave" %}
   7   <requestHandler name="/replication" class="solr.ReplicationHandler">
   6     <lst name="slave">
-  5       <str name="masterUrl">{{ solr_replication_master_url }}/{{ item.ident }}</str>
+  5       <str name="masterUrl">{{ solr_replication_master_url }}/{{ item.ident }}/replication</str>
   4       <str name="pollInterval">00:00:05</str>
   3     </lst>
   2   </requestHandler>

--- a/templates/hyrax_solrconfig/solrconfig_xml.j2
+++ b/templates/hyrax_solrconfig/solrconfig_xml.j2
@@ -57,7 +57,7 @@
     </lst>
   </requestHandler>
 {% endif %}
-        <!-- config for the admin interface -->
+          <!-- config for the admin interface -->
   <admin>
     <defaultQuery>*:*</defaultQuery>
   </admin>
@@ -270,7 +270,7 @@
   </updateRequestProcessorChain>
 {% endif %}
 
-      <!-- Spell Check
+        <!-- Spell Check
 
         The spell check component can return a list of alternative spelling
         suggestions.
@@ -411,7 +411,7 @@
 {% if solr_replication_node == "slave" %}
   <requestHandler name="/replication" class="solr.ReplicationHandler">
     <lst name="slave">
-      <str name="masterUrl">{{ solr_replication_master_url }}/{{ item.ident }}</str>
+      <str name="masterUrl">{{ solr_replication_master_url }}/{{ item.ident }}/replication</str>
       <str name="pollInterval">00:05:00</str>
     </lst>
   </requestHandler>

--- a/templates/ursus_solrconfig/solrconfig_xml.j2
+++ b/templates/ursus_solrconfig/solrconfig_xml.j2
@@ -53,7 +53,7 @@
     </lst>
   </requestHandler>
 {% endif %}
-        <!-- config for the admin interface -->
+          <!-- config for the admin interface -->
   <admin>
     <defaultQuery>*:*</defaultQuery>
   </admin>
@@ -237,7 +237,7 @@
     <processor class="solr.RunUpdateProcessorFactory" />
   </updateRequestProcessorChain>
   {% endif %}
-        <!-- Spell Check
+          <!-- Spell Check
 
         The spell check component can return a list of alternative spelling
         suggestions.
@@ -376,7 +376,7 @@
 {% if solr_replication_node == "slave" %}
   <requestHandler name="/replication" class="solr.ReplicationHandler">
     <lst name="slave">
-      <str name="masterUrl">{{ solr_replication_master_url }}/{{ item.ident }}</str>
+      <str name="masterUrl">{{ solr_replication_master_url }}/{{ item.ident }}/replication</str>
       <str name="pollInterval">00:05:00</str>
     </lst>
   </requestHandler>


### PR DESCRIPTION
        modified:   templates/avalon_solrconfig/solrconfig_xml.j2
	modified:   templates/hyrax_solrconfig/solrconfig_xml.j2
	modified:   templates/ursus_solrconfig/solrconfig_xml.j2
![image](https://user-images.githubusercontent.com/4259468/92983937-690ecb80-f45b-11ea-9d78-f4e2ce11e1e7.png)

the master url in the above file will change too 

 http://s-u-calursussolrmaster01.library.ucla.edu/solr/calursus/replication

as given in the solr guide
https://lucene.apache.org/solr/guide/7_5/index-replication.html#configuring-the-replication-requesthandler-on-a-slave-server