### PR TITLE
Remove docValues

### DIFF
--- a/files/hyrax_solr-conf/schema.xml
+++ b/files/hyrax_solr-conf/schema.xml
@@ -228,7 +228,7 @@
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
 
     <field name="title_alpha_numeric_ssort" type="alphaNumericSort" indexed="true" stored="false" multiValued="false"/>
-    <field name="date_dtsort" type="date" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="date_dtsort" type="date" indexed="true" stored="true" multiValued="false"/>
     <field name="shelfmark_alpha_numeric_ssort" type="alphaNumericSort" indexed="true" stored="true" multiValued="false"/>
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
 
@@ -257,12 +257,12 @@
     <dynamicField name="*_tesimv" type="text_en" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
     <!-- string (_s...) -->
-    <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false" docValues="true"/>
-    <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true" docValues="true"/>
-    <dynamicField name="*_ss" type="string" stored="true" indexed="false" multiValued="false" docValues="true"/>
-    <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true" docValues="true"/>
-    <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false" docValues="true"/>
-    <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true" docValues="true"/>
+    <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ss" type="string" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false"/>
 
     <!-- integer (_i...) -->


### PR DESCRIPTION
 "error":{
    "msg":"unexpected docvalues type NONE for field 'local_identifier_ssm' (expected one of [SORTED, SORTED_SET]). Re-index with correct docvalues type.",
    "trace":"java.lang.IllegalStateException: unexpected docvalues type NONE for field 'local_identifier_ssm' (expected one of [SORTED, SORTED_SET]). Re-index with correct docvalues type.\n\tat org.apache.lucene.index.DocValues.checkField(DocValues.java:340)\n\tat org.apache.lucene.index.DocValues.getSortedSet(DocValues.java:433)\n\tat org.apache.lucene.document.SortedSetDocValuesField$1.getValues(SortedSetDocValuesField.java:88)\n\tat 

To resolve this error we need a reindex as docvalues were added for testing performance issues with facet loading,on the test server.

The faster solution is to remove the docValues for now and add them back later if we see performance issues